### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,35 @@
 Role Name
 =========
 
-A brief description of the role goes here.
+Install and configure lustre clients and servers.
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+- By default this targets CentOS 7.9 (2009).
+- Appropriate (patched) kernel packages should be installed e.g. using [ansible-role-linux-kernel](https://github.com/mjrasobarnett/ansible-role-linux-kernel).
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+See `defaults/main.yml`.
 
 Dependencies
 ------------
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+None.
 
 Example Playbook
 ----------------
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+TODO
 
 License
 -------
 
-BSD
+TODO
 
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+TODO

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 #=====================
 # Accepted values here: 'server', 'client'
 lustre_install_type: 'server'
-lustre_version: '2.12.5'
+lustre_version: '2.12.7'
 # WARNING: use this variable to control whether this role will attempt
 # to format devices for Lustre
 lustre_format_disks: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,6 +69,20 @@ lustre_lnet_ko2iblnd_opa_options:
   fmr_cache: '1'
   conns_per_peer: '4'
 
+# LDISKFS variables - REQUIRED when lustre_format_disks = True
+lustre_fsname: lustre
+# See tasks/format-ldiskfs.yml for details, minimal requirements are:
+# lustre_format_mgs:
+#   device: # device path
+# lustre_format_mdts:
+#   device: # device path
+#   index: # a 0-based index
+#   mgs_nodes: # mgs NID
+# lustre_format_osts:
+#   device: # device path
+#   index: # a 0-based index
+#   mgs_nodes: # mgs NID
+
 # EXAMPLE legacy lnet module options
 #lustre_lnet_module_networks:
 #  - 'o2ib0(ib0)'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,10 +37,10 @@ lustre_install_debuginfo: true
 #lustre_format_ldiskfs_enable_wide_striping:
 #lustre_format_ldiskfs_reserved_blocks_percentage:
 
-# Choose whether to install custom Yum repo to install mofed from
+# Define yum repo to install lustre packages from
 lustre_manage_repo: true
 lustre_repo_name: 'lustre-{{ lustre_install_type }}'
-lustre_repo_baseurl: "https://downloads.whamcloud.com/public/lustre/lustre-{{ lustre_version }}/el{{ ansible_distribution_major_version }}/server"
+lustre_repo_baseurl: "https://downloads.whamcloud.com/public/lustre/lustre-{{ lustre_version }}/el{{ ansible_distribution_major_version }}"
 lustre_repo_description: "Lustre Server - Yum Repository for {{ ansible_os_family }} {{ ansible_distribution_version }} - {{ ansible_architecture }}"
 lustre_repo_enabled: true
 lustre_repo_gpgcheck: false

--- a/tasks/install-repo-RedHat.yml
+++ b/tasks/install-repo-RedHat.yml
@@ -6,7 +6,7 @@
       yum_repository:
         name: "{{ lustre_repo_name }}"
         description: "{{ lustre_repo_description }}"
-        baseurl: "{{ lustre_repo_baseurl }}"
+        baseurl: "{{ lustre_repo_baseurl }}/{{ lustre_install_type }}"
         gpgcheck: "{{ lustre_repo_gpgcheck | default('no') }}"
         gpgkey: "{{ lustre_repo_gpgkey | default(omit) }}"
         enabled: "{{ lustre_repo_enabled | default('no') }}"

--- a/tasks/lnet.yml
+++ b/tasks/lnet.yml
@@ -15,11 +15,12 @@
     src: "templates/lnet.conf.j2"
     dest: "/etc/lnet.conf"
   when: (lustre_lnet_lnetctl_networks is defined)
+  register: lustre_lnet_conf
 
 - name: "Ensure lnet service is started"
   service:
     name: 'lnet'
-    state: 'started'
+    state: "{{ 'restarted' if lustre_lnet_conf.changed else 'started' }}"
     enabled: true
 
 - name: "Ensure lnet routing parameters are configured correctly"


### PR DESCRIPTION
Various bugfixes and improvements to docs/defaults as per commit messages:
- bump default version to 2.12.7
- allow default repo baseurl usage to work for both server and client modes [ currently you *have* to override this as it has `/server` on the end]
- improve docs
- take account of changed lnet config [lnet service isn't currently reloaded if changed]