### PR TITLE
Mount MGT/MDT/OST by label instead of device

### DIFF
--- a/tasks/mount-ldiskfs.yml
+++ b/tasks/mount-ldiskfs.yml
@@ -9,7 +9,7 @@
         state: directory
 
     - name: "mount MGS"
-      command: "mount -t lustre {{ lustre_format_mgs.device }} {{ lustre_mount_prefix }}/MGS"
+      command: "mount -t lustre -L MGS {{ lustre_mount_prefix }}/MGS"
       register: cmd_mgs_result
       failed_when: "cmd_mgs_result.rc != 0 and ('is already mounted' not in cmd_mgs_result.stderr)"
       changed_when: "cmd_mgs_result.rc == 0"
@@ -25,7 +25,7 @@
       with_items: "{{ lustre_format_mdts }}"
 
     - name: "mount MDTs"
-      command: "mount -t lustre {{ item.device }} {{ lustre_mount_prefix }}/{{ lustre_fsname }}-MDT{{ '%04x' % item.index | int }}"
+      command: "mount -t lustre -L {{ lustre_fsname }}-MDT{{ '%04x' % item.index | int }} {{ lustre_mount_prefix }}/{{ lustre_fsname }}-MDT{{ '%04x' % item.index | int }}"
       register: cmd_mgt_result
       failed_when: "cmd_mgt_result.rc != 0 and ('is already mounted' not in cmd_mgt_result.stderr)"
       changed_when: "cmd_mgt_result.rc == 0"
@@ -42,7 +42,7 @@
       with_items: "{{ lustre_format_osts }}"
 
     - name: "mount OSTs"
-      command: "mount -t lustre {{ item.device }} {{ lustre_mount_prefix }}/{{ lustre_fsname }}-OST{{ '%04x' % item.index | int }}"
+      command: "mount -t lustre -L {{ lustre_fsname }}-OST{{ '%04x' % item.index | int }} {{ lustre_mount_prefix }}/{{ lustre_fsname }}-OST{{ '%04x' % item.index | int }}"
       register: cmd_ost_result
       failed_when: "cmd_ost_result.rc != 0 and ('is already mounted' not in cmd_ost_result.stderr)"
       changed_when: "cmd_ost_result.rc == 0"

--- a/tasks/mount-ldiskfs.yml
+++ b/tasks/mount-ldiskfs.yml
@@ -23,9 +23,14 @@
         path: "{{ lustre_mount_prefix }}/{{ lustre_fsname }}-MDT{{ '%04x' % item.index | int }}"
         state: directory
       with_items: "{{ lustre_format_mdts }}"
+    
+    - name: Get lustre MDT label format
+      shell: "lsblk -o label | grep -o [:-]MDT"
+      register: lsblk_mdt
+      changed_when: false
 
     - name: "mount MDTs"
-      command: "mount -t lustre -L {{ lustre_fsname }}-MDT{{ '%04x' % item.index | int }} {{ lustre_mount_prefix }}/{{ lustre_fsname }}-MDT{{ '%04x' % item.index | int }}"
+      command: "mount -t lustre -L {{ lustre_fsname }}{{ lsblk_mdt.stdout[0] }}MDT{{ '%04x' % item.index | int }} {{ lustre_mount_prefix }}/{{ lustre_fsname }}-MDT{{ '%04x' % item.index | int }}"
       register: cmd_mgt_result
       failed_when: "cmd_mgt_result.rc != 0 and ('is already mounted' not in cmd_mgt_result.stderr)"
       changed_when: "cmd_mgt_result.rc == 0"
@@ -41,8 +46,13 @@
         state: directory
       with_items: "{{ lustre_format_osts }}"
 
+    - name: Get lustre OST label format # will be same as MDT format but might not have run that
+      shell: "lsblk -o label | grep -o [:-]OST"
+      register: lsblk_ost
+      changed_when: false
+
     - name: "mount OSTs"
-      command: "mount -t lustre -L {{ lustre_fsname }}-OST{{ '%04x' % item.index | int }} {{ lustre_mount_prefix }}/{{ lustre_fsname }}-OST{{ '%04x' % item.index | int }}"
+      command: "mount -t lustre -L {{ lustre_fsname }}{{ lsblk_ost.stdout[0] }}OST{{ '%04x' % item.index | int }} {{ lustre_mount_prefix }}/{{ lustre_fsname }}-OST{{ '%04x' % item.index | int }}"
       register: cmd_ost_result
       failed_when: "cmd_ost_result.rc != 0 and ('is already mounted' not in cmd_ost_result.stderr)"
       changed_when: "cmd_ost_result.rc == 0"


### PR DESCRIPTION
Use lustre's automatic labelling of devices ([docs](https://doc.lustre.org/lustre_manual.xhtml#mount_by_label)) to mount MGT/MDT/OST filesystems by label rather than by device path. This is much safer as devices can be renumbered (e.g. multiple attached volumes sometimes swap devices after a reboot).

The above docs warn that:
> Mount-by-label should NOT be used in a multi-path environment or when snapshots are being created of the device, since multiple block devices will have the same label.

Presumably a "multi-path environment" is one with multiple MGSs on one server, which I don't think this role needs to support (yet)?

Is the snapshot scenario a concern?

Note that filesystem _creation_ still has to use device paths (obviously). Not so obviously, when using `lustre_format_disks: true` on previously created filesystems (which is idempotent, i.e. doesn't do anything) the current and requested device paths must still match even with this PR. This is not necessarily the case if the server has rebooted between the original and subsequent runs with `lustre_format_disks: true`, so once disks have been formatted this should be set `false`.