### PR TITLE
Fix disk formatting error handing for MGS case

### DIFF
--- a/library/ldiskfs_filesystem.py
+++ b/library/ldiskfs_filesystem.py
@@ -276,7 +276,7 @@ def main():
     dev = Device(module, dev)
 
     cmd = module.get_bin_path('blkid', required=True)
-    rc, raw_fs, err = module.run_command("%s -c /dev/null -o value -s TYPE %s" % (cmd, dev))
+    rc, raw_fs, err = module.run_command("%s -c /dev/null -o value -s TYPE %s" % (cmd, dev)) # raw_fs should just be the 
     # In case blkid isn't able to identify an existing filesystem, device is considered as empty,
     # then this existing filesystem would be overwritten even if force isn't enabled.
     fs = raw_fs.strip()
@@ -319,8 +319,7 @@ def main():
           existing_fs_name = match.group('fs_name')
           existing_target_type = match.group('target_type')
           existing_index = match.group('index')
-
-          new_index = format(index, '04x')
+          new_index = format(index, '04x') if index is not None else index # MGS has index=None
 
           if (existing_fs_name != fsname):
             module.fail_json(msg="Device '{}' is already used in a different filesystem {}, "

--- a/library/ldiskfs_filesystem.py
+++ b/library/ldiskfs_filesystem.py
@@ -328,7 +328,7 @@ def main():
           elif (existing_target_type.lower() != target_type):
             module.fail_json(msg="Device '{}' is already used as a different target type {}, "
                                  "full label: {}. Use force=yes to "
-                                 "overwrite".format(dev, existing_target_type, target_type, fs_label), rc=rc, err=err)
+                                 "overwrite".format(dev, existing_target_type, fs_label), rc=rc, err=err)
           elif (existing_index != new_index):
             module.fail_json(msg="Device '{}' is already used with a different index {}, instead of {}, "
                                  "full label: {}. Use force=yes to "

--- a/library/ldiskfs_filesystem.py
+++ b/library/ldiskfs_filesystem.py
@@ -276,7 +276,7 @@ def main():
     dev = Device(module, dev)
 
     cmd = module.get_bin_path('blkid', required=True)
-    rc, raw_fs, err = module.run_command("%s -c /dev/null -o value -s TYPE %s" % (cmd, dev)) # raw_fs should just be the 
+    rc, raw_fs, err = module.run_command("%s -c /dev/null -o value -s TYPE %s" % (cmd, dev))
     # In case blkid isn't able to identify an existing filesystem, device is considered as empty,
     # then this existing filesystem would be overwritten even if force isn't enabled.
     fs = raw_fs.strip()


### PR DESCRIPTION
TLRD: fixes a bug in the `ldiskfs_filesystem` module's error handing for the case where an attempt is made to format an existing MDT or OST filesystem as an MGT, without using `force`.

- MGT filesystems are different from MDT/OST: no index is/should be supplied to mkfs.lustre, and the generated fs label doesn't contain filesystem name or index.
- `ldiskfs_filesystem` module attempts idempotency (to make using  `lustre_format_disks: true` safe) by checking the device path, target type (mgt,mdt,ost) and index of an existing fileystem matches what's being requested. If so, it no-ops, if not, it errors unless `force` is provided.
- In the case where device paths have got swapped and module runs to create an MGT on an existing non-MGT fs:
  - MGT-specific logic at line 293 isn't triggered
  - No index is provided to the module (as it's not required for MGT), so defaults to `None`
  - Conversion of required index to leading-zero-padded hex number at line 322 fails.

The resulting traceback is:
```
"/tmp/ansible_ldiskfs_filesystem_payload_G7idxl/ansible_ldiskfs_filesystem_payload.zip/ansible/modules/ldiskfs_filesystem.py\", line 323, in main\r\nValueError: Unknown format code 'x' for object of type 'str'\r\n"
```

This PR fixes the error handing to cope with the no-index-provided case, meaning the correct error message is provided in this case from line 329: `Device '{}' is already used as a different target type {}, `

It also fixes an error with interpolating into that error message.