### PR TITLE
Add Rocky Linux support for clients

### DIFF
--- a/tasks/install-repo-RedHat.yml
+++ b/tasks/install-repo-RedHat.yml
@@ -2,6 +2,14 @@
 - name: "Configure Lustre package repository"
   when: lustre_manage_repo | bool
   block:
+
+    - name: Check Lustre repo URL is valid
+      uri:
+        url: "{{ lustre_repo_baseurl }}/{{ lustre_install_type }}"
+        method: HEAD
+      register: repo_uri_test
+      failed_when: repo_uri_test.status != 200
+
     - name: "Install Lustre packages yum repo"
       yum_repository:
         name: "{{ lustre_repo_name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,10 +4,19 @@
 
 # PyYAML is required for this role's modules to function, we force this
 # to be installed even in check-mode, since otherwise the modules will fail
+- name: "Check for python yaml support"
+  command:
+    cmd: "{{ ansible_python.executable }} -c 'import yaml'"
+  register: has_yaml
+  failed_when: false
+  changed_when: false
+  check_mode: no
+
 - name: "Install PyYAML package"
   package:
     name: "{{ lustre_pyyaml_package }}"
     state: present
+  when: has_yaml.rc != 0 # ModuleNotFoundError only introduced in python3.6
   check_mode: no
 
 - name: "Include OS-specific package installation tasks"


### PR DESCRIPTION
For clients at least the only issue is that the PyYaml package isn't available; the system python in EL8 is done a bit differently from CentOS7 anyway so installing using the system-python's `pip` doesn't feel like a good idea. As the `yaml` module is available in the python used by ansible under Rocky8 we just make this install conditional.